### PR TITLE
Fix security hole

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@ PKSpop
 A pipeline to predict type I PKSs protein order in polyketide biosynthetic assembly lines.
 
 
-PKSpop comprises three main steps to infer protein order: 1) Identify class memberships for query docking domains and align the sequences; 2) Pair each class I Ndd with all class I Cdds and use Ouroboros to predict the interaction probability for each pair. The probabilities are filled into a matrix; 3) Infer the protein order by a greedy probability matrix-filling method which takes the assembly line constraints and compatibility class into account.
+PKSpop comprises three main steps to infer protein order: 
+1. Identify class memberships for query docking domains and align the sequences
+2. Pair each class I Ndd with all class I Cdds and use Ouroboros to predict the interaction probability for each pair. The probabilities are filled into a matrix
+3. Infer the protein order by a greedy probability matrix-filling method which takes the assembly line constraints and compatibility class into account.
 
 # Run PKSpop
 ```
@@ -42,7 +45,8 @@ Additional files used in prediction process:
 This project is licensed under the BSD-3 license. See the LICENSE file for details.
 
 # Requirements
-Following tools should be installed/downloaded before running PKSpop:
+PKSpop requires Python 3.6+. The following tools should be installed/downloaded before running PKSpop:
 * [Ouroboros](https://github.com/miguelcorrea/Ouroboros)
 * [HMMER](https://hmmer.org)
+ 
 

--- a/code/run_analysis.py
+++ b/code/run_analysis.py
@@ -13,7 +13,14 @@ import subprocess
 from sys import argv
 import warnings
 import json
-import extract_seq, msa, query_seq, Ouroboros_analysis, int_prob, predict, cut_residues
+import extract_seq
+import msa
+import query_seq
+import Ouroboros_analysis
+import int_prob
+import predict
+import cut_residues
+
 
 def parse_input(inpt_path):
     '''
@@ -21,7 +28,7 @@ def parse_input(inpt_path):
     '''
     with open(inpt_path) as inpt:
         args = json.load(inpt)
-        
+
         gbk_path = args['gbk_path']
         pro_id = args['protein_id']
         id_category = args['id_category']
@@ -31,47 +38,45 @@ def parse_input(inpt_path):
         ouro_repeat = args['n_repeat']
     return args
 
+
 if __name__ == "__main__":
-    
+
     print('Analysis start......')
-    
+
     info_dict = parse_input(argv[1])
     result_path = info_dict['result_path']
     if os.path.exists(result_path):
-        cmd = f'rm -rf {result_path}'
-        subprocess.check_call(cmd, shell=True) #?
-    os.mkdir(result_path)
-    pred_oupt_path = f'{result_path}/output'
-    os.mkdir(pred_oupt_path)
-    
-    ### Extract whole docking domain sequences from genbank file
-    ### according to provided protein id information
+        raise FileExistsError(f"Output path {output_path} already exists")
+    else:
+        os.mkdir(result_path)
+        pred_oupt_path = f'{result_path}/output'
+        os.mkdir(pred_oupt_path)
+
+    # Extract whole docking domain sequences from genbank file
+    # according to provided protein id information
     extract_seq.extract_seq(info_dict)
-       
-    ### Cluster the docking domains into 3 classes, then align the 
-    ### class 1 sequences
+
+    # Cluster the docking domains into 3 classes, then align the
+    # class 1 sequences
     msa.clustering(info_dict)
     msa.msa(info_dict)
-    
-    ### Pair the query sequences and intergrate them with the interacting
-    ### sequences and extra sequences to perform Ouroboros analysis
+
+    # Pair the query sequences and intergrate them with the interacting
+    # sequences and extra sequences to perform Ouroboros analysis
     query_seq.prepare_query_fl(info_dict)
     print(info_dict)
-        
-    ### Run Ourorboros analysis with user-defined parameters and find
-    ### the result with the best LLH
+
+    # Run Ourorboros analysis with user-defined parameters and find
+    # the result with the best LLH
     Ouroboros_analysis.ouroboros_analysis(info_dict)
     print(info_dict)
-    
-    ### matrix and plot the matrix
-    info_dict['output_path']=pred_oupt_path
+
+    # matrix and plot the matrix
+    info_dict['output_path'] = pred_oupt_path
     int_prob.prob_mtx(info_dict)
     print(info_dict)
-    
-    ### Predict the protein order according to interaction probability, 
-    ### start/end protein, protein class
+
+    # Predict the protein order according to interaction probability,
+    # start/end protein, protein class
     predict.predict_order(info_dict)
     print(info_dict)
-    
-       
-    


### PR DESCRIPTION
run_analysis automatically deletes the output path if it already exists using rm -rf. This can lead to accidental deletion of files, but could also be used maliciously if e.g. we put it on a server. For example, if a user specifies "/" as the output path, the script will try to delete everything it can in that partition.
This change makes the script raise an error if the output path already exists (as well as some automatic PEP8'ification of the script).